### PR TITLE
Update __init__.py

### DIFF
--- a/Code/DL_net/model/__init__.py
+++ b/Code/DL_net/model/__init__.py
@@ -1,3 +1,4 @@
-from .unet_inception import MultiRes_UNet,MultiRes_UNetX5_crossDynamic,MultiRes_UNeT_test
+#from .unet_inception import MultiRes_UNet,MultiRes_UNetX5_crossDynamic,MultiRes_UNeT_test
+from .unet_inception import MultiRes_UNeT_test
 from .LF_attenton_denoise import LF_attention_denoise
 from .util import *


### PR DESCRIPTION
Looks like `MultiRes_UNet` and `MultiRes_UNetX5_crossDynamic` are not present in `unet_inception.py`. To successfully run the code like it is, only import the model `MultiRes_UNeT_test`.