### PR TITLE
Fix and clean 'eval_test.py'

### DIFF
--- a/Code/DL_net/eval_test.py
+++ b/Code/DL_net/eval_test.py
@@ -103,7 +103,7 @@ def infer(epoch, batch_size=1, use_cpu=False):
                                                 )
 
     SR_ckpt_file = [filename for filename in os.listdir(checkpoint_dir) if
-                    ('.npz' in filename and epoch in filename and 'denoise' in filename)]
+                    ('.npz' in filename and epoch in filename and 'SR' in filename)]
     Recon_ckpt_file = [filename for filename in os.listdir(checkpoint_dir) if
                        ('.npz' in filename and epoch in filename and 'recon' in filename)]
 

--- a/Code/DL_net/eval_test.py
+++ b/Code/DL_net/eval_test.py
@@ -86,21 +86,13 @@ def infer(epoch, batch_size=1, use_cpu=False):
         SR_net = LF_attention_denoise(LFP=t_image, output_size=SR_size, sr_factor=sr_factor, angRes=n_num,
                                   reuse=False, name=config.net_setting.SR_model,
                              channels_interp=64, normalize_mode=normalize_mode)
-        if config.net_setting.Recon_model=='MultiRes':
-            Recon_net = MultiRes_UNet(n_interp=1,sub_pixel=3,
-                lf_extra=SR_net.outputs,
-                                      n_slices=n_slices,
-                                      output_size=Recon_size,
-                                      is_train=True, reuse=False, name=config.net_setting.Recon_model,
-                                      channels_interp=channels_interp, normalize_mode=normalize_mode,
-                                      transform='SAI2ViewStack')
-        elif config.net_setting.Recon_model == 'MultiRes_UNeT_test':
-            Recon_net = MultiRes_UNeT_test(lf_extra=SR_net.outputs,
-                                                n_slices=n_slices,
-                                                output_size=Recon_size,
-                                                is_train=True, reuse=False, name=config.net_setting.Recon_model,
-                                                channels_interp=channels_interp, normalize_mode=normalize_mode
-                                                )
+
+        Recon_net = MultiRes_UNeT_test(lf_extra=SR_net.outputs,
+                                            n_slices=n_slices,
+                                            output_size=Recon_size,
+                                            is_train=True, reuse=False, name=config.net_setting.Recon_model,
+                                            channels_interp=channels_interp, normalize_mode=normalize_mode
+                                            )
 
     SR_ckpt_file = [filename for filename in os.listdir(checkpoint_dir) if
                     ('.npz' in filename and epoch in filename and 'SR' in filename)]


### PR DESCRIPTION
Looks like the denoising checkpoint name has been changed from 'denoise_net' to 'SR_net'. See 'train.py' for reference in line 242. Also, models like `MultiRes_UNet` are missing from the code, therefore some options are not available.